### PR TITLE
Close 6

### DIFF
--- a/tests/testthat/test-as_matrix.R
+++ b/tests/testthat/test-as_matrix.R
@@ -1,0 +1,24 @@
+context("test-as_matrix.R")
+
+x <- correlate(mtcars)
+y <- as_matrix(x)
+
+test_that("Inherits correct classes", {
+  expect_is(y, "matrix")
+})
+
+test_that("Converts values accurately", {
+  expect_true(all(x[-1] == y, na.rm = TRUE))
+})
+
+test_that("Yields correct columns and rows", {
+  expect_equal(colnames(x), c("rowname", colnames(y)))
+  expect_equal(nrow(x), ncol(y))
+  expect_equal(x$rowname, colnames(y))
+  expect_equal(rownames(y), colnames(y))
+})
+
+test_that("Diagonal sets correctly", {
+  expect_true(all(diag(y) == 1))
+  expect_true(all(diag(as_matrix(x, diagonal = 100)) == 100))
+})

--- a/tests/testthat/test-as_matrix.R
+++ b/tests/testthat/test-as_matrix.R
@@ -1,4 +1,4 @@
-context("test-as_matrix.R")
+context("as_matrix.R")
 
 x <- correlate(mtcars)
 y <- as_matrix(x)


### PR DESCRIPTION
Just add test for `as_matrix`, which closes issue #6 . They're very similar to the test of `as_cordf` but w/ a few tweaks.